### PR TITLE
MNT: implement meta PV configuration in local config 

### DIFF
--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -35,7 +35,7 @@ class MongoBackend(_Backend):
         self._tag_cache = {}
         self._last_tag_fetch = datetime.now() - timedelta(minutes=1)
 
-    def search(self, *search_terms: SearchTermType):
+    def search(self, *search_terms: SearchTermType, meta_pvs=None):
         """
         Search for all entries matching the passed search terms.
 
@@ -49,7 +49,7 @@ class MongoBackend(_Backend):
         for attr, op, target in search_terms:
             if attr == "entry_type":
                 if target is Snapshot:
-                    entries = self.get_snapshots()
+                    entries = self.get_snapshots(meta_pvs=meta_pvs)
                 else:
                     entries = self.get_all_pvs()
         for entry in entries:
@@ -461,7 +461,7 @@ class MongoBackend(_Backend):
             params={
                 "title": title,
                 "tags": tags,
-                "metadataPVs": meta_pvs,
+                "metadataPVs": [pv.readback for pv in meta_pvs if pv.readback]
             }
         )
         self._raise_for_status(r)

--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -631,8 +631,7 @@ class MongoBackend(_Backend):
             creation_time=datetime.fromisoformat(metadata_dict["createdDate"]).replace(tzinfo=UTC),
         )
 
-    @staticmethod
-    def _unpack_snapshot(snapshot_dict) -> Snapshot:
+    def _unpack_snapshot(self, snapshot_dict) -> Snapshot:
         """
         Converts data received from backend endpoints into a complete Snapshot
         instance.
@@ -648,22 +647,45 @@ class MongoBackend(_Backend):
             Snapshot instance containing all encoded data received from the
             backend
         """
+        pv_defs = self.get_all_pvs()
+        pvs = []
+        pv_values_map = {}
+        for pv in pv_defs:
+            pv_with_values = PV(
+                setpoint=pv.setpoint,
+                readback=pv.readback,
+            )
+            if pv.setpoint:
+                pv_values_map[pv.setpoint] = pv_with_values
+            if pv.readback:
+                pv_values_map[pv.readback] = pv_with_values
+            pvs.append(pv_with_values)
+
+        for value_dict in snapshot_dict["data"]:
+            data = EpicsData(
+                data=value_dict.get("data", None),
+                status=getattr(Status, value_dict["status"]),
+                severity=getattr(Severity, value_dict["severity"]),
+                timestamp=datetime.fromisoformat(value_dict["createdDate"]).replace(tzinfo=UTC),
+            )
+            address = value_dict["pvName"]
+            try:
+                pv = pv_values_map[address]
+            except KeyError:
+                logging.debug(f"Address {address} within Snapshot did not match any PV from backend")
+            else:
+                if address == pv.setpoint:
+                    pv.setpoint_data = data
+                elif address == pv.readback:
+                    pv.readback_data = data
+                else:
+                    logging.debug("Address {address} did not match PV address {pv.setpoint} or {pv.readback}; skipping")
         return Snapshot(
             uuid=snapshot_dict["id"],
             title=snapshot_dict["title"],
             description=snapshot_dict["description"],
             # tags=snapshot_dict["tags"],
-            pvs=[
-                PV(
-                    setpoint=pv["pvName"],
-                    setpoint_data=EpicsData(
-                        data=pv.get("data", None),
-                        status=getattr(Status, pv["status"]),
-                        severity=getattr(Severity, pv["severity"]),
-                        timestamp=datetime.fromisoformat(pv["createdDate"]).replace(tzinfo=UTC),
-                    )
-                ) for pv in snapshot_dict["data"]
-            ],
+            pvs=pvs,
             creation_time=datetime.fromisoformat(snapshot_dict["createdDate"]).replace(tzinfo=UTC),
         )
 

--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -41,11 +41,6 @@ class MongoBackend(_Backend):
 
         .. deprecated
 
-        Returns
-        -------
-        TagDef
-            Full tag definition received from the backend
-
         Raises
         ------
         BackendError
@@ -500,24 +495,6 @@ class MongoBackend(_Backend):
         method is potentially valuable for limiting how much data is sent by the
         backend at once."""
         raise NotImplementedError
-
-    def get_meta_pvs(self) -> Iterable[PV]:
-        """
-        Dummy method that does nothing, but is required for
-        compatibility with the current Client
-
-        .. deprecated
-        """
-        return []
-
-    def set_meta_pvs(self, meta_pvs: Iterable[PV]) -> None:
-        """
-        Dummy method that does nothing, but is required for
-        compatibility with the current Client
-
-        .. deprecated
-        """
-        return
 
     @staticmethod
     def _raise_for_status(response):

--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -702,15 +702,24 @@ class MongoBackend(_Backend):
         -------
         dict
         """
+        setpoint_values = [
+            {
+                "pvName": pv.setpoint,
+                "status": pv.setpoint_data.status.name,
+                "severity": pv.setpoint_data.severity.name,
+                "data": pv.setpoint_data.data,
+            } for pv in snapshot.pvs if pv.setpoint
+        ]
+        readback_values = [
+            {
+                "pvName": pv.readback,
+                "status": pv.readback_data.status.name,
+                "severity": pv.readback_data.severity.name,
+                "data": pv.readback_data.data,
+            } for pv in snapshot.pvs if pv.readback
+        ]
         return {
             "title": snapshot.title,
             "description": snapshot.description,
-            "values": [
-                {
-                    "pvName": pv.setpoint,
-                    "status": pv.setpoint_data.status.name,
-                    "severity": pv.setpoint_data.severity.name,
-                    "data": pv.setpoint_data.data,
-                } for pv in snapshot.pvs
-            ],
+            "values": setpoint_values + readback_values,
         }

--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -611,10 +611,20 @@ class MongoBackend(_Backend):
             # tags=metadata_dict["tags"],
             meta_pvs=[
                 PV(
-                    setpoint=pv["setpointAddress"],
-                    data=pv["data"],
-                    status=getattr(Status, pv["status"]),
-                    severity=getattr(Severity, pv["severity"]),
+                    setpoint=pv.get("setpointAddress", ""),
+                    setpoint_data=EpicsData(
+                        data=pv.get("data", None),
+                        status=getattr(Status, pv["status"]),
+                        severity=getattr(Severity, pv["severity"]),
+                        timestamp=datetime.fromisoformat(pv["createdDate"]).replace(tzinfo=UTC),
+                    ),
+                    readback=pv.get("readbackAddress", ""),
+                    readback_data=EpicsData(
+                        data=pv.get("data", None),
+                        status=getattr(Status, pv["status"]),
+                        severity=getattr(Severity, pv["severity"]),
+                        timestamp=datetime.fromisoformat(pv["createdDate"]).replace(tzinfo=UTC),
+                    ),
                     creation_time=datetime.fromisoformat(pv["createdDate"]).replace(tzinfo=UTC),
                 ) for pv in metadata_dict["metadataPVs"]
             ],

--- a/squirrel/tables/snapshot_table.py
+++ b/squirrel/tables/snapshot_table.py
@@ -27,7 +27,7 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
         return len(self._data)
 
     def columnCount(self, parent=None):
-        meta_pvs = self.client.backend.get_meta_pvs()
+        meta_pvs = self.client.meta_pvs
         return len(self.HEADER) + len(meta_pvs)
 
     def data(
@@ -44,13 +44,13 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
                 return snapshot.title
             else:
                 try:
-                    return snapshot.meta_pvs[column - len(self.HEADER)].data
+                    return snapshot.meta_pvs[column - len(self.HEADER)].readback_data.data
                 except IndexError:
                     return None
         elif role == QtCore.Qt.ToolTipRole and column >= 2:
             snapshot = self._data[index.row()]
             try:
-                return snapshot.meta_pvs[column - len(self.HEADER)].pv_name
+                return snapshot.meta_pvs[column - len(self.HEADER)].readback
             except IndexError:
                 return None
         else:
@@ -67,7 +67,7 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
                 try:
                     return self.HEADER[section]
                 except IndexError:
-                    meta_pvs = self.client.backend.get_meta_pvs()
+                    meta_pvs = self.client.meta_pvs
                     return meta_pvs[section - len(self.HEADER)].description
 
     def fetch(self):

--- a/squirrel/tables/snapshot_table.py
+++ b/squirrel/tables/snapshot_table.py
@@ -74,7 +74,7 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
         """Fetch all snapshots from the backend"""
         self.beginResetModel()
         self._data = sorted(
-            self.client.search(("entry_type", "eq", Snapshot)),
+            self.client.backend.get_snapshots(meta_pvs=self.client.meta_pvs),
             key=lambda s: s.creation_time,
             reverse=True,
         )

--- a/squirrel/tests/demo.cfg
+++ b/squirrel/tests/demo.cfg
@@ -6,5 +6,7 @@ address = http://dev-daemon9:8080
 ca = true
 pva = true
 
-[demo]
-fixtures = linac_with_comparison_snapshot
+[meta PVs]
+pvs=BEND:DMPH:400:BDES
+    BEND:DMPH:400:EDES
+    SIOC:SYS0:ML00:CALC252

--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -152,7 +152,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         date_range.rangeChanged.connect(proxy_model.setDateRange)
 
         # Set up the filters for the meta pv columns
-        meta_columns = [pv.description for pv in self.client.backend.get_meta_pvs()]
+        meta_columns = [pv.readback for pv in self.client.meta_pvs if pv.readback]
         self.meta_pv_filter_popup = QtWidgets.QFrame(self)
         self.meta_pv_filter_popup.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self.meta_pv_filter_popup.setWindowFlags(QtCore.Qt.Popup)


### PR DESCRIPTION
TODO: edit documentation

## Description
<!--- Describe individual changes -->
Backends will no longer store meta PV configurations. Meta PVs will be configured in the local config. PVs must exist normally in the backend to be used as meta PVs. In this PR, only `PV.readback`s can be used as meta PVs. 

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
